### PR TITLE
Add .idea/.name to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/.name
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
This file is not useful to have in the git (used by android-studio to
know the name of the project, see
https://stackoverflow.com/a/28434813/7158887).