### PR TITLE
Add Firestore database

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'jacoco'
+    id 'com.google.gms.google-services'
 }
 
 android {
@@ -80,6 +81,14 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+
+    // Firebase
+    implementation platform('com.google.firebase:firebase-bom:26.6.0')
+    implementation 'com.google.firebase:firebase-firestore-ktx'
+    implementation 'com.google.firebase:firebase-storage-ktx'
+    implementation 'com.firebaseui:firebase-ui-storage:6.4.0'
+
+    // Test frameworks
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation('com.schibsted.spain:barista:3.8.0') {

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "511027907553",
+    "project_id": "human-learning-app",
+    "storage_bucket": "human-learning-app.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:511027907553:android:b33af54d509560a8f160a0",
+        "android_client_info": {
+          "package_name": "com.github.HumanLearning2021.HumanLearningApp"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "511027907553-p0sqbict6r6hh81bdrrp1v73idj2tshh.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyC5eHV4qLeWm_JT0cwnKslI-Mts9w6oA8g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "511027907553-p0sqbict6r6hh81bdrrp1v73idj2tshh.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/DatabaseTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/DatabaseTest.kt
@@ -1,0 +1,25 @@
+package com.github.HumanLearning2021.HumanLearningApp
+
+import com.github.HumanLearning2021.HumanLearningApp.datamodel.Category
+import com.github.HumanLearning2021.HumanLearningApp.datamodel.Picture
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.firestore.ktx.toObject
+import com.google.firebase.ktx.Firebase
+import junit.framework.TestCase
+
+class DatabaseTest : TestCase() {
+    fun testLoadApple() {
+        Firebase.firestore.document("/databases/demo/pictures/minecraft_apple").get()
+            .continueWithTask {
+                val img = it.result?.toObject<Picture>()
+                assertNotNull(img?.category)
+                img!!.category!!.get()
+            }.continueWith {
+            val category = it.result?.toObject<Category>()
+            assertNotNull(category)
+        }.also {
+            while (!it.isComplete) {
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/datamodel/Category.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/datamodel/Category.kt
@@ -1,0 +1,11 @@
+package com.github.HumanLearning2021.HumanLearningApp.datamodel
+
+/** Plain object for the database entity that represents an abstract category that learners can
+ * learn to recognize and classify.
+ */
+data class Category(
+    /** Name of the category in user language. */
+    val name: String? = null,
+    /** Level 1: presentation, (default) level 2: representation */
+    val comWoorLevel: Int = 1,
+)

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/datamodel/Picture.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/datamodel/Picture.kt
@@ -1,0 +1,12 @@
+package com.github.HumanLearning2021.HumanLearningApp.datamodel
+
+import com.google.firebase.firestore.DocumentReference
+
+/** Plain object for the database entity that represents a picture that learners can classify.
+ */
+data class Picture(
+    /** Location of the image in Cloud Storage. */
+    val url: String? = null,
+    /** The category that the picture depicts. (mandatory) */
+    val category: DocumentReference? = null,
+)

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.gms:google-services:4.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
# Current state
This contains a working example of getting and displaying data from Google Firebase. Goal: #6

# TODO
- [x] Need to not do this in `MainActivity`, maybe turn it into a unit test
- [x] Can we make a team/organization thingy on the Google side?
- [x] dataclasses

# Points to bring up at Standup meeting
- ~~I need other contributors' google accounts so I can give them admin access.~~
- The current database I made read-only from the app. This is good for some automated tests, but we probably want to add a sandbox database and later a production database.
- We could put dummy datasets and the like in sub-hierarchies
- ~~Martin is working on an issue assigned to me without pinging me.~~