### PR TITLE
[cleanup] address or mark compilation warnings

### DIFF
--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDatabaseManagementTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDatabaseManagementTest.kt
@@ -67,6 +67,7 @@ class FirestoreDatabaseManagementTest {
         })
     }
 
+    @Suppress("DEPRECATED")
     @Test
     fun test_getPicture() = runBlocking {
         val appleCategory = demoManagement.getCategoryById(appleCategoryId)

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDatabaseServiceTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDatabaseServiceTest.kt
@@ -105,6 +105,7 @@ class FirestoreDatabaseServiceTest {
         })
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun test_removePicture() = runBlocking {
         val randomCategoryName = "${UUID.randomUUID()}"

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/model/DemoDatabaseServiceTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/model/DemoDatabaseServiceTest.kt
@@ -27,6 +27,7 @@ abstract class DemoDatabaseServiceTest : TestCase() {
         assertThat(cat, hasName("Pomme"))
     }
 
+    @Suppress("DEPRECATION")
     fun test_getPicture() = runBlocking {
         val appleCategory = db.getCategories().find { it.name == "Pomme" }
         requireNotNull(appleCategory, { "category of apples no found in demo dataset" })

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/model/DemoDatabaseServiceTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/model/DemoDatabaseServiceTest.kt
@@ -3,9 +3,9 @@ package com.github.HumanLearning2021.HumanLearningApp.model
 import com.github.HumanLearning2021.HumanLearningApp.firestore.FirestoreDatabaseService
 import junit.framework.TestCase
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasItem
-import org.junit.Assert.assertThat
 
 
 abstract class DemoDatabaseServiceTest : TestCase() {

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/model/ScratchDatabaseServiceTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/model/ScratchDatabaseServiceTest.kt
@@ -8,8 +8,8 @@ import com.google.firebase.ktx.Firebase
 import junit.framework.TestCase
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Assert.assertThat
 
 
 abstract class ScratchDatabaseServiceTest : TestCase() {

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/presenter/AuthenticationPresenterTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/presenter/AuthenticationPresenterTest.kt
@@ -8,8 +8,8 @@ import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
-import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/AudioFeedbackTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/AudioFeedbackTest.kt
@@ -12,7 +12,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.notNullValue
-import org.junit.Assert.assertThat
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/LearningTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/LearningTest.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.runBlocking
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.CoreMatchers.`is`
-import org.junit.Assert.assertThat
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDatabaseService.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDatabaseService.kt
@@ -167,7 +167,7 @@ class FirestoreDatabaseService internal constructor(
 
     override suspend fun getDataset(id: Any): FirestoreDataset? {
         require(id is String)
-        val ds = datasets.document(id as String).get().await().toObject(DatasetSchema::class.java)
+        val ds = datasets.document(id).get().await().toObject(DatasetSchema::class.java)
         return ds?.toPublic()
     }
 
@@ -176,7 +176,7 @@ class FirestoreDatabaseService internal constructor(
             throw java.lang.IllegalArgumentException("Dataset with id $id is not contained in the databse")
         }
         try {
-            datasets.document(id as String).delete().await()
+            datasets.document(id).delete().await()
         } catch (e: FirebaseFirestoreException) {
             Log.w(this.toString(), "Deleting dataset ${datasets.id} from ${this.db} failed", e)
         }
@@ -331,7 +331,7 @@ class FirestoreDatabaseService internal constructor(
 
     override suspend fun getCategory(categoryId: Any): FirestoreCategory? {
         require(categoryId is String)
-        val cat = categories.document(categoryId as String).get().await()
+        val cat = categories.document(categoryId).get().await()
             .toObject(CategorySchema::class.java)
         return cat?.toPublic()
     }

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreUser.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreUser.kt
@@ -1,7 +1,7 @@
 package com.github.HumanLearning2021.HumanLearningApp.firestore
 
 import com.github.HumanLearning2021.HumanLearningApp.model.User
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class FirestoreUser(

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseManagement.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseManagement.kt
@@ -140,7 +140,7 @@ data class DummyDatabaseManagement internal constructor(
         require(picture is DummyCategorizedPicture)
         try {
             databaseService.putRepresentativePicture(
-                (picture as DummyCategorizedPicture).picture,
+                picture.picture,
                 picture.category
             )
         } catch (e: IllegalArgumentException) {

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseService.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseService.kt
@@ -202,7 +202,7 @@ class DummyDatabaseService internal constructor() : DatabaseService {
                     addAll(categories)
                     remove(c)
                 }
-                val newDs = DummyDataset(dataset.id as String, dataset.name, newCategories as Set<Category>)
+                val newDs = DummyDataset(dataset.id, dataset.name, newCategories as Set<Category>)
                 this.datasets.apply {
                     add(newDs)
                     remove(dataset)

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyUser.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyUser.kt
@@ -1,6 +1,6 @@
 package com.github.HumanLearning2021.HumanLearningApp.model
 
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class DummyUser(

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/GoogleSignInWidget.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/GoogleSignInWidget.kt
@@ -40,6 +40,7 @@ class GoogleSignInWidget : Fragment() {
     }
 
     private fun onLoginButtonPress() {
+        @Suppress("DEPRECATION")  // FIXME: use something non-deprecated
         startActivityForResult(
             presenter.intentForStartActivityForResult(),
             RC_SIGN_IN
@@ -48,6 +49,7 @@ class GoogleSignInWidget : Fragment() {
 
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        @Suppress("DEPRECATION")  // FIXME: use something non-deprecated
         super.onActivityResult(requestCode, resultCode, data)
 
         when (requestCode) {

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/GoogleSignInWidget.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/GoogleSignInWidget.kt
@@ -33,11 +33,13 @@ class GoogleSignInWidget : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.findViewById<Button>(R.id.loginButton).setOnClickListener(this::onLoginButtonPress)
+        view.findViewById<Button>(R.id.loginButton).setOnClickListener {
+            onLoginButtonPress()
+        }
         updateUi()
     }
 
-    fun onLoginButtonPress(view: View) {
+    private fun onLoginButtonPress() {
         startActivityForResult(
             presenter.intentForStartActivityForResult(),
             RC_SIGN_IN

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/MainActivity.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/MainActivity.kt
@@ -16,11 +16,11 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
     }
 
-    fun launchToDisplayDatasetActivity(view: View) {
+    fun launchToDisplayDatasetActivity(@Suppress("UNUSED_PARAMETER") view: View) {
         startActivity(Intent(this, DisplayDatasetActivity::class.java))
     }
 
-    fun launchToLearningActivity(view: View) {
+    fun launchToLearningActivity(@Suppress("UNUSED_PARAMETER") view: View) {
         startActivity(Intent(this, LearningDatasetSelectionActivity::class.java))
     }
 }

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureActivity.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureActivity.kt
@@ -71,6 +71,7 @@ class AddPictureActivity : AppCompatActivity() {
 
     private fun checkIntentExtras(extras: Bundle?) {
         if (extras != null && extras["categories"] is ArrayList<*>) {
+            @Suppress("UNCHECKED_CAST")  // due to type erasure
             val givenCategories = extras["categories"] as ArrayList<Category>
             categories = categories.plus(givenCategories)
         }

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DatasetsOverviewActivity.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DatasetsOverviewActivity.kt
@@ -25,7 +25,7 @@ class DatasetsOverviewActivity : AppCompatActivity() {
         }
     }
 
-    fun launchDataCreationActivity(view: View){
+    fun launchDataCreationActivity(@Suppress("UNUSED_PARAMETER") view: View){
         startActivity(Intent(this, CategoriesEditingActivity::class.java))
     }
 }

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayDatasetActivity.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayDatasetActivity.kt
@@ -104,12 +104,12 @@ class DisplayDatasetActivity : AppCompatActivity() {
         private var layoutInflater =
             context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
 
-        override fun getView(position: Int, view: View?, viewGroup: ViewGroup?): View {
+        override fun getView(position: Int, view0: View?, viewGroup: ViewGroup?): View {
             val view =
-                view ?: layoutInflater.inflate(R.layout.image_and_category_item, viewGroup!!, false)
+                view0 ?: layoutInflater.inflate(R.layout.image_and_category_item, viewGroup!!, false)
 
-            val imageCat = view?.findViewById<TextView>(R.id.image_and_category_item_imageCategory)
-            val imageView = view?.findViewById<ImageView>(R.id.image_and_category_item_imageView)
+            val imageCat = view.findViewById<TextView>(R.id.image_and_category_item_imageCategory)
+            val imageView = view.findViewById<ImageView>(R.id.image_and_category_item_imageView)
 
             imageCat?.text = images.elementAt(position).category.name
             images.elementAt(position).displayOn(context, imageView as ImageView)
@@ -142,7 +142,7 @@ class DisplayDatasetActivity : AppCompatActivity() {
     }
 
     private fun setGridViewItemListener() {
-        findViewById<GridView>(R.id.display_dataset_imagesGridView).setOnItemClickListener { adapterView, view, i, l ->
+        findViewById<GridView>(R.id.display_dataset_imagesGridView).setOnItemClickListener { _, _, i, _ ->
             val cat = categories.elementAt(i)
             val intent =
                 Intent(this@DisplayDatasetActivity, DisplayImageSetActivity::class.java)

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayImageSetActivity.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayImageSetActivity.kt
@@ -72,11 +72,11 @@ class DisplayImageSetActivity : AppCompatActivity() {
         private var layoutInflater =
             context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
 
-        override fun getView(position: Int, view: View?, viewGroup: ViewGroup?): View {
+        override fun getView(position: Int, view0: View?, viewGroup: ViewGroup?): View {
             val view =
-                view ?: layoutInflater.inflate(R.layout.image_item, viewGroup, false)
+                view0 ?: layoutInflater.inflate(R.layout.image_item, viewGroup!!, false)
 
-            val imageView = view?.findViewById<ImageView>(R.id.image_item_imageView)
+            val imageView = view.findViewById<ImageView>(R.id.image_item_imageView)
 
             images.elementAt(position).displayOn(context, imageView as ImageView)
 
@@ -98,7 +98,7 @@ class DisplayImageSetActivity : AppCompatActivity() {
     }
 
     private fun setPictureItemListener(){
-        findViewById<GridView>(R.id.display_image_set_imagesGridView).setOnItemClickListener { adapterView, view, i, l ->
+        findViewById<GridView>(R.id.display_image_set_imagesGridView).setOnItemClickListener { _, _, i, _ ->
             val intent =
                 Intent(this@DisplayImageSetActivity, DisplayImageActivity::class.java)
             intent.putExtra(

--- a/app/src/test/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseManagementTest.kt
+++ b/app/src/test/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseManagementTest.kt
@@ -36,18 +36,21 @@ class DummyDatabaseManagementTest {
     private val spoonPic = DummyCategorizedPicture("spoonpicid", spoon, spoonUri)
 
     @ExperimentalCoroutinesApi
+    @Suppress("DEPRECATION")
     @Test(expected = IllegalArgumentException::class)
     fun getPictureThrowsIllegalArgumentException() = runBlockingTest {
         testDatabaseManagement.getPicture(table)
     }
 
     @ExperimentalCoroutinesApi
+    @Suppress("DEPRECATION")
     @Test
     fun getPictureWorks() = runBlockingTest {
         assert(testDatabaseManagement.getPicture(fork)!! == forkPic)
     }
 
     @ExperimentalCoroutinesApi
+    @Suppress("DEPRECATION")
     @Test
     fun putAndThenGetWorks() = runBlockingTest {
         val newCat = testDatabaseManagement.putCategory("Table")

--- a/app/src/test/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseManagementTest.kt
+++ b/app/src/test/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseManagementTest.kt
@@ -51,7 +51,7 @@ class DummyDatabaseManagementTest {
     @Test
     fun putAndThenGetWorks() = runBlockingTest {
         val newCat = testDatabaseManagement.putCategory("Table")
-        val newPic = testDatabaseManagement.putPicture(knifeUri, newCat)
+        testDatabaseManagement.putPicture(knifeUri, newCat)
         assert(testDatabaseManagement.getPicture(newCat) != null)
     }
 
@@ -174,9 +174,9 @@ class DummyDatabaseManagementTest {
     @ExperimentalCoroutinesApi
     @Test
     fun deleteDatasetWorks() = runBlockingTest {
-        val dummyDatabaseService = DummyDatabaseService()
-        testDatabaseManagement.deleteDataset("kitchen utensils")
-        assert(!dummyDatabaseService.getDatasets().contains("kitchen utensils"))
+        val id = "kitchen utensils"
+        testDatabaseManagement.deleteDataset(id)
+        assert(!testDatabaseManagement.getDatasetIds().contains(id))
     }
 
     @ExperimentalCoroutinesApi

--- a/app/src/test/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseServiceTest.kt
+++ b/app/src/test/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseServiceTest.kt
@@ -11,6 +11,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+
 @RunWith(RobolectricTestRunner::class)
 class DummyDatabaseServiceTest {
 
@@ -28,6 +29,7 @@ class DummyDatabaseServiceTest {
     private val spoonPic = DummyCategorizedPicture("spoonpicid", spoon, spoonUri)
 
     @ExperimentalCoroutinesApi
+    @Suppress("DEPRECATION")
     @Test
     fun getForkWorks() = runBlockingTest {
         val dummyDatabaseService = DummyDatabaseService()
@@ -37,12 +39,14 @@ class DummyDatabaseServiceTest {
     }
 
     @ExperimentalCoroutinesApi
+    @Suppress("DEPRECATION")
     @Test(expected = IllegalArgumentException::class)
     fun getPictureCategoryNotPresentThrows() = runBlockingTest {
         DummyDatabaseService().getPicture(DummyCategory("Plate", "Plate"))
     }
 
     @ExperimentalCoroutinesApi
+    @Suppress("DEPRECATION")
     @Test
     fun getPictureCategoryEmpty() = runBlockingTest {
         val dummyDatabaseService = DummyDatabaseService()
@@ -55,6 +59,7 @@ class DummyDatabaseServiceTest {
 
 
     @ExperimentalCoroutinesApi
+    @Suppress("DEPRECATION")
     @Test
     fun putAndThenGetWorks() = runBlockingTest {
         val dummyDatabaseService = DummyDatabaseService()


### PR DESCRIPTION
This addresses all warnings seen when building the App, save for two:

- `ExperimentalStdlibAPI` things. That should resolve itself over time when it's no longer experimental.
- A couple codegen warnings around Room. We can deal with that in Room-related PRs.