### PR TITLE
[hotfix] add demo database write protection to emulator firestore rules

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+	"rules": "firestore.rules"
+  },
   "emulators": {
     "auth": {
       "port": 9099

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+  // {database} is always "(default)"
+  // hence, we fake having distinct databases by creating subcollections
+  match /databases/{dbName}/{documentPath=**} {
+      allow read;
+      allow write: if dbName == "scratch" || dbName == "demo2";
+  }
+  }
+}


### PR DESCRIPTION
Add write protection to the demo database in the emulator. This is needed since the emulator is not reset between each test and hence makes assumptions of consistency for the demo database unenforced.