### PR TITLE
Feature/123 make learning clearer

### DIFF
--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/LearningTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/LearningTest.kt
@@ -66,7 +66,7 @@ class LearningTest {
 
     @Test
     fun allImageViewsAreDisplayed() {
-        assertDisplayed(R.id.learning_im_to_sort)
+        assertDisplayed(R.id.learning_to_sort)
         assertDisplayed(R.id.learning_cat_0)
         assertDisplayed(R.id.learning_cat_1)
         assertDisplayed(R.id.learning_cat_2)

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/LearningFragment.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/LearningFragment.kt
@@ -9,7 +9,6 @@ import android.util.Log
 import android.view.*
 import android.widget.ImageView
 import androidx.activity.OnBackPressedCallback
-import androidx.cardview.widget.CardView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -121,7 +120,7 @@ class LearningFragment: Fragment() {
     }
 
 
-    private fun initImageView(catIvId: Int, cat: Category): ImageView? {
+    private fun initImageView(catIvId: Int, cat: Category): ImageView {
         val catIv = when(catIvId) {
             R.id.learning_cat_0 -> binding.learningCat0
             R.id.learning_cat_1 -> binding.learningCat1
@@ -129,22 +128,20 @@ class LearningFragment: Fragment() {
             else -> binding.learningToSort
         }
 
-        // TODO (next sprint) make this less hacky
+        // TODO (next sprint) make this more robust
         // The mechanism to verify that the classification is correct is the comparison between
         // the contentDescription of the target ImageView and the text carried in the drag & drop
         // see LearningActivity::dropCallback
-        if (catIv != null) {
-            catIv.contentDescription = cat.name
-            Log.d(parentActivity.localClassName, "init contentDescription to ${cat.name}")
+        catIv.contentDescription = cat.name
+        Log.d(parentActivity.localClassName, "init contentDescription to ${cat.name}")
 
-            if (catIvId == R.id.learning_to_sort) {
-                lifecycleScope.launch {
-                    learningPresenter.displayNextPicture(parentActivity, catIv)
-                }
-            } else {
-                lifecycleScope.launch {
-                    learningPresenter.displayTargetPicture(parentActivity, catIv, cat)
-                }
+        if (catIvId == R.id.learning_to_sort) {
+            lifecycleScope.launch {
+                learningPresenter.displayNextPicture(parentActivity, catIv)
+            }
+        } else {
+            lifecycleScope.launch {
+                learningPresenter.displayTargetPicture(parentActivity, catIv, cat)
             }
         }
 
@@ -156,14 +153,14 @@ class LearningFragment: Fragment() {
      * This method initializes the image view containing the image to sort
      */
     private fun initImageToSort(catIvId: Int, cat: Category) {
-        initImageView(catIvId, cat)?.setOnTouchListener{e, v -> onImageToSortTouched(e, v)}
+        initImageView(catIvId, cat).setOnTouchListener{ e, v -> onImageToSortTouched(e, v)}
     }
 
     /**
      * This method initializes an image view representing a target category
      */
     private fun initTargetCategory(catIvId: Int, cat: Category) {
-        initImageView(catIvId, cat)?.setOnDragListener(targetOnDragListener)
+        initImageView(catIvId, cat).setOnDragListener(targetOnDragListener)
     }
 
     private val opaque = 1.0f
@@ -195,7 +192,7 @@ class LearningFragment: Fragment() {
         setOpacity(v, opaque)
         Log.d(parentActivity.localClassName, "dropped : ${item.text} on category: ${v.contentDescription}")
 
-        // TODO (next sprint) make this less hacky
+        // TODO (future sprint) make this more robust
         // the classification is considered correct if the text carried by the drag
         // is equal to the contentDescription of the target ImageView
         val res = item.text == v.contentDescription
@@ -204,7 +201,7 @@ class LearningFragment: Fragment() {
         if (res) {
             audioFeedback.startCorrectFeedback()
             lifecycleScope.launch {
-                binding.learningToSort?.let {
+                binding.learningToSort.let {
                     learningPresenter.displayNextPicture(
                         self,
                         it,
@@ -228,13 +225,12 @@ class LearningFragment: Fragment() {
     }
 
     private fun onImageToSortTouched(view: View, event: MotionEvent): Boolean {
-        val clipDataLabel = "My Clip Data"
         return when (event.action) {
             MotionEvent.ACTION_DOWN -> {
-                // TODO (next sprint) change this to setCurrentCategory in presenter
+                // TODO (future sprint) make verification mechanism more robust
                 val item = ClipData.Item(view.contentDescription)
                 val dragData = ClipData(
-                    clipDataLabel,
+                    getString(R.string.learning_clipdata_label),
                     arrayOf(ClipDescription.MIMETYPE_TEXT_PLAIN),
                     item
                 )

--- a/app/src/main/res/layout-land/fragment_learning.xml
+++ b/app/src/main/res/layout-land/fragment_learning.xml
@@ -7,7 +7,7 @@
     tools:context=".view.learning.LearningFragment">
 
     <ImageView
-        android:id="@+id/learning_im_to_sort"
+        android:id="@+id/learning_to_sort"
         android:layout_width="@dimen/learning_image_size_land"
         android:layout_height="@dimen/learning_image_size_land"
         android:background="@color/white"

--- a/app/src/main/res/layout-sw600dp-land/fragment_learning.xml
+++ b/app/src/main/res/layout-sw600dp-land/fragment_learning.xml
@@ -7,7 +7,7 @@
     tools:context=".view.learning.LearningFragment">
 
     <ImageView
-        android:id="@+id/learning_im_to_sort"
+        android:id="@+id/learning_to_sort"
         android:layout_width="@dimen/learning_image_size_tablet_land"
         android:layout_height="@dimen/learning_image_size_tablet_land"
         android:background="@color/white"

--- a/app/src/main/res/layout-sw600dp/fragment_learning.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_learning.xml
@@ -7,7 +7,7 @@
     tools:context=".view.learning.LearningFragment">
 
     <ImageView
-        android:id="@+id/learning_im_to_sort"
+        android:id="@+id/learning_to_sort"
         android:layout_width="@dimen/learning_image_size_tablet"
         android:layout_height="@dimen/learning_image_size_tablet"
         android:background="@color/white"

--- a/app/src/main/res/layout/fragment_learning.xml
+++ b/app/src/main/res/layout/fragment_learning.xml
@@ -6,19 +6,33 @@
     android:layout_height="match_parent"
     tools:context=".view.learning.LearningFragment">
 
-    <ImageView
-        android:id="@+id/learning_im_to_sort"
+    <!-- Sadly this file contains a lot of copy pasted things (The CardViews with ImageView inside)
+        But I don't know how to avoid this for the time being. Maybe a fragment?
+        <include layout="..."> didn't compile
+        (said there were duplicate ids, but in reality not).
+    -->
+    <androidx.cardview.widget.CardView
+        android:id="@+id/learning_to_sort_cv"
         android:layout_width="@dimen/learning_image_size"
         android:layout_height="@dimen/learning_image_size"
-        android:background="@color/white"
-        android:contentDescription="@string/learning_im_to_sort_descr"
-        android:longClickable="true"
+        app:cardBackgroundColor="@color/light_green"
+        app:cardCornerRadius="@dimen/learning_image_corner_radius"
+
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/learning_guideline1"
-        app:srcCompat="@color/blue" />
+        >
+
+        <ImageView
+            android:id="@+id/learning_to_sort"
+            android:layout_width="match_parent"
+            android:scaleType="centerCrop"
+            android:layout_height="match_parent"
+            android:padding="@dimen/learning_image_border_width"
+            app:srcCompat="@color/blue" />
+    </androidx.cardview.widget.CardView>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/constraintLayout"
@@ -27,44 +41,72 @@
         app:layout_constraintBottom_toTopOf="@id/learning_guideline1"
         app:layout_constraintTop_toTopOf="parent">
 
-        <ImageView
-            android:id="@+id/learning_cat_0"
+        <androidx.cardview.widget.CardView
+            android:id="@+id/learning_cat_0_cv"
             android:layout_width="@dimen/learning_image_size"
             android:layout_height="@dimen/learning_image_size"
-            android:background="@color/white"
-            android:contentDescription="@string/learning_cat_0_descr"
-            android:scaleType="centerCrop"
+            app:cardBackgroundColor="@color/white"
+            app:cardCornerRadius="@dimen/learning_image_corner_radius"
+
+
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/learning_cat_1"
+            app:layout_constraintEnd_toStartOf="@+id/learning_cat_1_cv"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@color/red" />
+            >
 
-        <ImageView
-            android:id="@+id/learning_cat_1"
+            <ImageView
+                android:id="@+id/learning_cat_0"
+                android:layout_width="match_parent"
+                android:scaleType="centerCrop"
+                android:layout_height="match_parent"
+                android:padding="@dimen/learning_image_border_width"
+                app:srcCompat="@color/blue" />
+        </androidx.cardview.widget.CardView>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/learning_cat_1_cv"
             android:layout_width="@dimen/learning_image_size"
             android:layout_height="@dimen/learning_image_size"
-            android:background="@color/white"
-            android:contentDescription="@string/learning_cat_1_descr"
-            android:scaleType="centerCrop"
+            app:cardBackgroundColor="@color/white"
+            app:cardCornerRadius="@dimen/learning_image_corner_radius"
+
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/learning_cat_2"
-            app:layout_constraintStart_toEndOf="@+id/learning_cat_0"
+            app:layout_constraintEnd_toStartOf="@+id/learning_cat_2_cv"
+            app:layout_constraintStart_toEndOf="@+id/learning_cat_0_cv"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@color/green" />
+            >
 
-        <ImageView
-            android:id="@+id/learning_cat_2"
+            <ImageView
+                android:id="@+id/learning_cat_1"
+                android:layout_width="match_parent"
+                android:scaleType="centerCrop"
+                android:layout_height="match_parent"
+                android:padding="@dimen/learning_image_border_width"
+                app:srcCompat="@color/blue" />
+        </androidx.cardview.widget.CardView>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/learning_cat_2_cv"
             android:layout_width="@dimen/learning_image_size"
             android:layout_height="@dimen/learning_image_size"
-            android:background="@color/white"
-            android:contentDescription="@string/learning_cat_2_descr"
-            android:scaleType="centerCrop"
+            app:cardBackgroundColor="@color/white"
+            app:cardCornerRadius="@dimen/learning_image_corner_radius"
+
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/learning_cat_1"
+            app:layout_constraintStart_toEndOf="@+id/learning_cat_1_cv"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@color/blue" />
+            >
+
+            <ImageView
+                android:id="@+id/learning_cat_2"
+                android:layout_width="match_parent"
+                android:scaleType="centerCrop"
+                android:layout_height="match_parent"
+                android:padding="@dimen/learning_image_border_width"
+                app:srcCompat="@color/blue" />
+        </androidx.cardview.widget.CardView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/learning_image.xml
+++ b/app/src/main/res/layout/learning_image.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/learning_image.xml
+++ b/app/src/main/res/layout/learning_image.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,5 +12,6 @@
     <color name="white">#FFFFFFFF</color>
     <color name="red">#f00</color>
     <color name="green">#0f0</color>
+    <color name="light_green">#B2FF59</color>
     <color name="blue">#00f</color>
 </resources>

--- a/app/src/main/res/values/learning.xml
+++ b/app/src/main/res/values/learning.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="learning_image_size">128dp</dimen>
+    <dimen name="learning_image_size">100dp</dimen>
     <dimen name="learning_image_size_land">110dp</dimen>
     <dimen name="learning_image_size_tablet">220dp</dimen>
     <dimen name="learning_image_size_tablet_land">180dp</dimen>
+
+    <dimen name="learning_image_border_width">10dp</dimen>
+    <dimen name="learning_image_corner_radius">8dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="learning_cat_0_descr">red</string>
     <string name="learning_cat_1_descr">green</string>
     <string name="learning_cat_2_descr">blue</string>
+    <string name="learning_clipdata_label">Image to sort category</string>
     <string name="learning_settings_tooltip_presentation">Learn in presentation mode: an image must be classified against an exact copy</string>
     <string name="learning_settings_tooltip_representation">Learn in representation mode: an image must be classified against a representative of its category</string>
     <string name="learning_settings_btPresentation">PRESENTATION</string>


### PR DESCRIPTION
Wraps images from learning UI inside a card view to have rounded corners and a border that indicates with which element to interact.

The idea was that first the image to sort has a green border to indicate that you should interact with it. Then, once you start dragging it, the target categories have the green border, to indicate you should drag the image on one of the targets. If it is wrong, the border of the category turns red to indicate a mistake.

This could not be implemented yet because of a lack of time on my part. I'll add an issue so that we can implement this in a future sprint.