### PR TITLE
Refactor/177 Flatten POKO hierarchy

### DIFF
--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/TakePictureActivityTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/TakePictureActivityTest.kt
@@ -25,7 +25,6 @@ import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
-import kotlinx.parcelize.Parcelize
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.FixMethodOrder
@@ -64,12 +63,6 @@ class TakePictureActivityTest {
     private fun grantCameraPermission() {
         PermissionGranter.allowPermissionOneTime(Manifest.permission.CAMERA)
     }
-
-    @Parcelize
-    private class TestCat(
-        override val id: String, override val name: String
-    ) : Category
-
 
     @Before
     fun setUp() {

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreCategory.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreCategory.kt
@@ -1,11 +1,9 @@
 package com.github.HumanLearning2021.HumanLearningApp.firestore
 
 import com.github.HumanLearning2021.HumanLearningApp.model.Category
-import com.github.HumanLearning2021.HumanLearningApp.model.Id
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
-data class FirestoreCategory internal constructor(
-    override val id: Id,
-    override val name: String
-) : Category
+@Deprecated(
+    "merged with superclass",
+    ReplaceWith("Category", "com.github.HumanLearning2021.HumanLearningApp.model.Category"),
+)
+typealias FirestoreCategory = Category

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDataset.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDataset.kt
@@ -1,12 +1,9 @@
 package com.github.HumanLearning2021.HumanLearningApp.firestore
 
 import com.github.HumanLearning2021.HumanLearningApp.model.Dataset
-import com.github.HumanLearning2021.HumanLearningApp.model.Id
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
-class FirestoreDataset(
-    override val id: Id,
-    override val name: String,
-    override val categories: Set<FirestoreCategory>
-) : Dataset
+@Deprecated(
+    "merged with superclass",
+    ReplaceWith("Dataset", "com.github.HumanLearning2021.HumanLearningApp.model.Dataset")
+)
+typealias FirestoreDataset = Dataset

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreUser.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreUser.kt
@@ -1,12 +1,9 @@
 package com.github.HumanLearning2021.HumanLearningApp.firestore
 
 import com.github.HumanLearning2021.HumanLearningApp.model.User
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
-data class FirestoreUser(
-    override val displayName: String?,
-    override val email: String?,
-    override val uid: String,
-    override val type: User.Type,
-) : User
+@Deprecated(
+    "merged with superclass",
+    ReplaceWith("User", "com.github.HumanLearning2021.HumanLearningApp.model.User")
+)
+typealias FirestoreUser = User

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/Category.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/Category.kt
@@ -1,12 +1,13 @@
 package com.github.HumanLearning2021.HumanLearningApp.model
 
 import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
 /**
- * An interface representing a category to which a CategorizedPicture can belong
- * id is used to uniquely identify a Category
+ * Class representing a category to which a CategorizedPicture can belong
+ *
+ * @property name the name of the category (case-sensitive)
+ * @property id uniquely identifies the category
  */
-interface Category : Parcelable {
-    val id: Id
-    val name: String
-}
+@Parcelize
+data class Category(val id: Id, val name: String) : Parcelable

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/Dataset.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/Dataset.kt
@@ -1,18 +1,20 @@
 package com.github.HumanLearning2021.HumanLearningApp.model
 
 import android.os.Parcelable
-
+import kotlinx.parcelize.Parcelize
 
 /**
- * Interface describing a Dataset.
- * @property id should be used to uniquely identify the Dataset
+ * Representation of a Dataset.
+ * @property id uniquely identifies the Dataset
  * @property name Human readable name of the Dataset
  * @property categories Set of Category included in the Dataset
  */
-interface Dataset : Parcelable {
-    val id: Id
-    val name: String
+
+@Parcelize
+data class Dataset(
+    val id: Id,
+    val name: String,
     val categories: Set<Category>
-}
+) : Parcelable
 
 typealias DatasetId = Id

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyCategory.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyCategory.kt
@@ -1,13 +1,8 @@
 package com.github.HumanLearning2021.HumanLearningApp.model
 
-import kotlinx.parcelize.Parcelize
 
-/**
- * Class representing a dummy implementation of the category interface
- *
- * @param name the name of the category (case-sensitive)
- * @param id uniquely identifies the category
- * @param representativePicture a categorized picture, can be null
- */
-@Parcelize
-data class DummyCategory(override val id: Id, override val name: String) : Category
+@Deprecated(
+    "merged with superclass",
+    ReplaceWith("Category"),
+)
+typealias DummyCategory = Category

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDataset.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDataset.kt
@@ -1,10 +1,4 @@
 package com.github.HumanLearning2021.HumanLearningApp.model
 
-import kotlinx.parcelize.Parcelize
-
-@Parcelize
-data class DummyDataset(
-    override val id: Id,
-    override val name: String,
-    override val categories: Set<Category>
-) : Dataset
+@Deprecated("merged with superclass", ReplaceWith("Dataset"))
+typealias DummyDataset = Dataset

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyUser.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyUser.kt
@@ -1,11 +1,4 @@
 package com.github.HumanLearning2021.HumanLearningApp.model
 
-import kotlinx.parcelize.Parcelize
-
-@Parcelize
-data class DummyUser(
-    override val displayName: String?,
-    override val email: String?,
-    override val uid: String,
-    override val type: User.Type,
-) : User
+@Deprecated("merged with superclass", ReplaceWith("User"))
+typealias DummyUser = User

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/User.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/User.kt
@@ -6,16 +6,18 @@ import kotlinx.parcelize.Parcelize
 /**
  * primary key: (type, uid)
  */
-interface User : Parcelable {
+@Parcelize
+data class User(
+    val displayName: String?,
+    val email: String?,
+    val uid: String,
+    val type: Type,
+) : Parcelable {
+    
     enum class Type {
         FIREBASE,
         TEST,
     }
-
-    val type: Type
-    val uid: String
-    val displayName: String?
-    val email: String?
 
     @Parcelize
     data class Id(val uid: String, val type: Type) : Parcelable {

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineCategory.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineCategory.kt
@@ -1,7 +1,9 @@
 package com.github.HumanLearning2021.HumanLearningApp.offline
 
 import com.github.HumanLearning2021.HumanLearningApp.model.Category
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
-class OfflineCategory(override val id: String, override val name: String) : Category
+@Deprecated(
+    "merged with superclass",
+    ReplaceWith("Category", "com.github.HumanLearning2021.HumanLearningApp.model.Category"),
+)
+typealias OfflineCategory = Category

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineConverters.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineConverters.kt
@@ -35,6 +35,11 @@ object OfflineConverters {
     }
 
     fun fromUser(user: RoomUser): OfflineUser {
-        return OfflineUser(user.type, user.userId, user.displayName, user.email)
+        return OfflineUser(
+            displayName = user.displayName,
+            email = user.email,
+            user.userId,
+            user.type,
+        )
     }
 }

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineDataset.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineDataset.kt
@@ -1,11 +1,9 @@
 package com.github.HumanLearning2021.HumanLearningApp.offline
 
 import com.github.HumanLearning2021.HumanLearningApp.model.Dataset
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
-class OfflineDataset(
-    override val id: String,
-    override val name: String,
-    override val categories: Set<OfflineCategory>
-) : Dataset
+@Deprecated(
+    "merged with superclass",
+    ReplaceWith("Dataset", "com.github.HumanLearning2021.HumanLearningApp.model.Dataset")
+)
+typealias OfflineDataset = Dataset

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineUser.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineUser.kt
@@ -1,12 +1,9 @@
 package com.github.HumanLearning2021.HumanLearningApp.offline
 
 import com.github.HumanLearning2021.HumanLearningApp.model.User
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
-class OfflineUser(
-    override val type: User.Type,
-    override val uid: String,
-    override val displayName: String?,
-    override val email: String?
-) : User
+@Deprecated(
+    "merged with superclass",
+    ReplaceWith("User", "com.github.HumanLearning2021.HumanLearningApp.model.User")
+)
+typealias OfflineUser = User


### PR DESCRIPTION
For #177 I'm going to submit multiple PRs in increasing order of invasiveness.

This PR flattens the POKO hierarchy as recommended in the code review.

Note: It adds a ton of deprecation warnings. That's so as to minimize the amount of lines touched and potential conflicts. At some point where we have no PRs outstanding, we can auto-refactor those out.