### PR TITLE
[housekeeping] Bump dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ android {
     buildFeatures {
         viewBinding true
     }
-    
+
     viewBinding {
         enabled = true
     }
@@ -114,10 +114,11 @@ connectedCheck {
 }
 dependencies {
 
-    def fragment_version = "1.3.0"
+    def fragment_version = "1.3.3"
+    def room_version = "2.3.0"
 
     apply plugin: 'kotlin-parcelize'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
@@ -126,10 +127,10 @@ dependencies {
     //set to 1.3.0 on purpose instead of 1.3.1 because otherwise cirrus crashes
     //noinspection GradleDependency
     implementation "androidx.fragment:fragment-ktx:$fragment_version"
-    implementation 'androidx.activity:activity-ktx:1.2.1'
+    implementation 'androidx.activity:activity-ktx:1.2.3'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.4.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
 
@@ -168,11 +169,11 @@ dependencies {
 
 
     //Room
-    implementation "androidx.room:room-runtime:2.3.0-rc01"
-    kapt "androidx.room:room-compiler:2.2.6"
-    implementation "androidx.room:room-ktx:2.2.6"
+    implementation "androidx.room:room-runtime:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
     // Fix Room incremental Processing
-    annotationProcessor "androidx.room:room-compiler:2.3.0-rc01"
+    annotationProcessor "androidx.room:room-compiler:$room_version"
 
     // Navigation Component dependencies
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = "1.4.31"
-    ext.hilt_version = '2.33-beta'
-    ext.nav_version = "2.3.0"
+    ext.hilt_version = '2.35'
+    ext.nav_version = "2.3.5"
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
- Kotlin 1.5 breaks jacoco reports, hence it has been skipped
- Android SDK 4.2 and/or gradle 6.7 break some stuff, hence they are not there