### PR TITLE
[bugfix] fix a bug occuring when setting a representative picture

### DIFF
--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDatabaseService.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/firestore/FirestoreDatabaseService.kt
@@ -224,6 +224,15 @@ class FirestoreDatabaseService internal constructor(
 
     override suspend fun putRepresentativePicture(picture: CategorizedPicture) {
         require(picture is FirestoreCategorizedPicture)
+        val ref = pictures.document(picture.id)
+        if (!ref.get().await().exists()) {
+            throw DatabaseService.NotFoundException(picture.id)
+        }
+        try {
+            ref.delete().await()
+        } catch (e: FirebaseFirestoreException) {
+            Log.w(this.toString(), "Removing picture ${picture.url} from ${this.db} failed", e)
+        }
         putRepresentativePicture(picture.url, picture.category)
     }
 

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DefaultDatabaseManagement.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DefaultDatabaseManagement.kt
@@ -137,7 +137,6 @@ class DefaultDatabaseManagement internal constructor(
      */
     override suspend fun putRepresentativePicture(picture: CategorizedPicture) {
         databaseService.putRepresentativePicture(picture)
-        removePicture(picture)
     }
 
     override suspend fun getDatasets(): Set<Dataset> {
@@ -188,8 +187,10 @@ class DefaultDatabaseManagement internal constructor(
 
     override suspend fun countOccurrence(user: User.Id, dataset: Id, event: Event) {
         (databaseService.getStatistic(user, dataset) ?: Statistic(
-            Statistic.Id(user,
-            dataset),
+            Statistic.Id(
+                user,
+                dataset
+            ),
             mapOf()
         )).let { stat ->
             stat.copy(occurrences = stat.occurrences.let {

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseService.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseService.kt
@@ -196,6 +196,7 @@ class DummyDatabaseService internal constructor() : DatabaseService {
     override suspend fun putRepresentativePicture(picture: CategorizedPicture) {
         require(picture is DummyCategorizedPicture)
         putRepresentativePicture(picture.picture, picture.category)
+        pictures.remove(picture)
     }
 
     override suspend fun getDatasets(): Set<Dataset> {

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineDatabaseService.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/offline/OfflineDatabaseService.kt
@@ -182,6 +182,7 @@ class OfflineDatabaseService internal constructor(
     override suspend fun putRepresentativePicture(picture: CategorizedPicture) {
         require(picture is OfflineCategorizedPicture)
         putRepresentativePicture(picture.picture, picture.category)
+        categoryDao.loadPicture(picture.id)?.let { categoryDao.delete(it) }
     }
 
     override suspend fun getDatasets(): Set<OfflineDataset> {


### PR DESCRIPTION
Fix a bug where setting a representative picture from a categorized picture already present in the dataset would lead to said picture being deleted from storage. This caused a crash because the app would try to load an image from a non-existant url.