### PR TITLE
Refactor DummyDatabaseService using the Repository Pattern

### DIFF
--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/GeneralNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/GeneralNavigationTest.kt
@@ -64,7 +64,7 @@ class GeneralNavigationTest {
     var dbName = "dummy"
 
     lateinit var dbMgt: DatabaseManagement
-    
+
     @BindValue
     val authPresenter = AuthenticationPresenter(AuthUI.getInstance(), DummyDatabaseService())
 

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/SearchTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/SearchTest.kt
@@ -62,7 +62,7 @@ class SearchTest {
     var dbName = "dummy"
 
     lateinit var dbMgt: DatabaseManagement
-    
+
     @BindValue
     val authPresenter = AuthenticationPresenter(AuthUI.getInstance(), DummyDatabaseService())
 

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureActivityTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureActivityTest.kt
@@ -12,6 +12,9 @@ import com.github.HumanLearning2021.HumanLearningApp.TestUtils
 import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseNameModule
 import com.github.HumanLearning2021.HumanLearningApp.hilt.GlobalDatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.hilt.ProductionDatabaseName
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseManagementModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseServiceModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.Demo2Database
 import com.github.HumanLearning2021.HumanLearningApp.model.*
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions
 import dagger.hilt.android.testing.BindValue

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureNavigationTest.kt
@@ -21,6 +21,9 @@ import com.github.HumanLearning2021.HumanLearningApp.R
 import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseNameModule
 import com.github.HumanLearning2021.HumanLearningApp.hilt.GlobalDatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.hilt.ProductionDatabaseName
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseManagementModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseServiceModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.Demo2Database
 import com.github.HumanLearning2021.HumanLearningApp.model.*
 import com.github.HumanLearning2021.HumanLearningApp.presenter.AuthenticationPresenter
 import com.github.HumanLearning2021.HumanLearningApp.view.MainActivity

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayDatasetActivityTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayDatasetActivityTest.kt
@@ -27,6 +27,9 @@ import com.github.HumanLearning2021.HumanLearningApp.TestUtils.waitFor
 import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseNameModule
 import com.github.HumanLearning2021.HumanLearningApp.hilt.GlobalDatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.hilt.ProductionDatabaseName
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseManagementModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseServiceModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.Demo2Database
 import com.github.HumanLearning2021.HumanLearningApp.model.*
 import com.github.HumanLearning2021.HumanLearningApp.presenter.AuthenticationPresenter
 import com.github.HumanLearning2021.HumanLearningApp.view.MainActivity

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayImageActivityTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayImageActivityTest.kt
@@ -18,6 +18,9 @@ import com.github.HumanLearning2021.HumanLearningApp.TestUtils.getFirstDataset
 import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseNameModule
 import com.github.HumanLearning2021.HumanLearningApp.hilt.GlobalDatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.hilt.ProductionDatabaseName
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseManagementModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseServiceModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.Demo2Database
 import com.github.HumanLearning2021.HumanLearningApp.model.*
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/MetadataEditingFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/MetadataEditingFragmentTest.kt
@@ -27,6 +27,9 @@ import com.github.HumanLearning2021.HumanLearningApp.TestUtils.withIndex
 import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseNameModule
 import com.github.HumanLearning2021.HumanLearningApp.hilt.GlobalDatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.hilt.ProductionDatabaseName
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseManagementModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseServiceModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.Demo2Database
 import com.github.HumanLearning2021.HumanLearningApp.model.DatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.model.Dataset
 import com.github.HumanLearning2021.HumanLearningApp.model.DummyDatabaseService
@@ -68,6 +71,8 @@ class MetadataEditingFragmentTest {
             MainActivity::class.java
         )
     )
+
+    private val dbService = DatabaseServiceModule.provideDummyService()
 
     @BindValue
     @ProductionDatabaseName

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/SelectPictureActivityTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/SelectPictureActivityTest.kt
@@ -23,6 +23,9 @@ import com.github.HumanLearning2021.HumanLearningApp.TestUtils
 import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseNameModule
 import com.github.HumanLearning2021.HumanLearningApp.hilt.GlobalDatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.hilt.ProductionDatabaseName
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseManagementModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseServiceModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.Demo2Database
 import com.github.HumanLearning2021.HumanLearningApp.model.*
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions
 import dagger.hilt.android.testing.BindValue

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/TakePictureActivityTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/TakePictureActivityTest.kt
@@ -24,6 +24,10 @@ import com.github.HumanLearning2021.HumanLearningApp.model.Category
 import com.github.HumanLearning2021.HumanLearningApp.model.DatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.model.DummyCategory
 import com.github.HumanLearning2021.HumanLearningApp.model.UniqueDatabaseManagement
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseManagementModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseServiceModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.Demo2Database
+import com.github.HumanLearning2021.HumanLearningApp.model.*
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.schibsted.spain.barista.interaction.PermissionGranter
 import dagger.hilt.android.qualifiers.ApplicationContext

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/AudioFeedbackTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/AudioFeedbackTest.kt
@@ -10,6 +10,9 @@ import com.github.HumanLearning2021.HumanLearningApp.TestUtils.getFirstDataset
 import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseNameModule
 import com.github.HumanLearning2021.HumanLearningApp.hilt.GlobalDatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.hilt.ProductionDatabaseName
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseManagementModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseServiceModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.Demo2Database
 import com.github.HumanLearning2021.HumanLearningApp.model.*
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/LearningTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/learning/LearningTest.kt
@@ -15,6 +15,9 @@ import com.github.HumanLearning2021.HumanLearningApp.TestUtils.getDatasetWithNCa
 import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseNameModule
 import com.github.HumanLearning2021.HumanLearningApp.hilt.GlobalDatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.hilt.ProductionDatabaseName
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseManagementModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.DatabaseServiceModule
+import com.github.HumanLearning2021.HumanLearningApp.hilt.Demo2Database
 import com.github.HumanLearning2021.HumanLearningApp.model.DatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.model.Id
 import com.github.HumanLearning2021.HumanLearningApp.model.UniqueDatabaseManagement

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/hilt/modules.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/hilt/modules.kt
@@ -1,8 +1,10 @@
 package com.github.HumanLearning2021.HumanLearningApp.hilt
 
 import android.content.Context
+import android.net.Uri
 import androidx.room.Room
 import com.firebase.ui.auth.AuthUI
+import com.github.HumanLearning2021.HumanLearningApp.R
 import com.github.HumanLearning2021.HumanLearningApp.firestore.FirestoreDatabaseService
 import com.github.HumanLearning2021.HumanLearningApp.model.*
 import com.github.HumanLearning2021.HumanLearningApp.offline.CachePictureRepository
@@ -163,7 +165,29 @@ object DatabaseServiceModule {
     @DummyDatabase
     @Provides
     @Singleton  // allows dummy data to persist across activities
-    fun provideDummyService(): DatabaseService = DummyDatabaseService()
+    fun provideDummyService(): DatabaseService = DummyDatabaseService().apply {
+        // Inject expected dummy data
+        val forkUri =
+            Uri.parse("android.resource://com.github.HumanLearning2021.HumanLearningApp/" + R.drawable.fork)
+        val knifeUri =
+            Uri.parse("android.resource://com.github.HumanLearning2021.HumanLearningApp/" + R.drawable.knife)
+        val spoonUri =
+            Uri.parse("android.resource://com.github.HumanLearning2021.HumanLearningApp/" + R.drawable.spoon)
+        runBlocking {
+            // fork2 allows us to have a dataset with 4 categories without needing a new test picture
+            val fork2 = putCategory("Fork2")
+            val fork = putCategory("Fork")
+            val knife = putCategory("Knife")
+            val spoon = putCategory("Spoon")
+            putDataset("kitchen utensils", setOf(fork, spoon, knife))
+            putDataset("one category", setOf(fork))
+            putDataset("two categories", setOf(fork, knife))
+            putDataset("four categories", setOf(fork, knife, spoon, fork2))
+            putPicture(forkUri, fork)
+            putPicture(knifeUri, knife)
+            putPicture(spoonUri, spoon)
+        }
+    }
 
     @OfflineDemoDatabase
     @Provides

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseService.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/DummyDatabaseService.kt
@@ -1,8 +1,6 @@
 package com.github.HumanLearning2021.HumanLearningApp.model
 
 import android.net.Uri
-import android.util.Log
-import com.github.HumanLearning2021.HumanLearningApp.R
 import com.google.firebase.auth.FirebaseUser
 import java.util.*
 
@@ -11,93 +9,38 @@ import java.util.*
  * Categories are uniquely defined by their name
  */
 class DummyDatabaseService internal constructor() : DatabaseService {
-    private val fork = DummyCategory("Fork", "Fork")
-
-    // fork2 allows us to have a dataset with 4 categories without needing a new test picture
-    private val fork2 = DummyCategory("Fork2", "Fork2")
-    private val knife = DummyCategory("Knife", "Knife")
-    private val spoon = DummyCategory("Spoon", "Spoon")
-
-    private val forkPic = DummyCategorizedPicture(
-        "forkpicid",
-        fork,
-        Uri.parse("android.resource://com.github.HumanLearning2021.HumanLearningApp/" + R.drawable.fork)
-    )
-    private val knifePic = DummyCategorizedPicture(
-        "knifepicid",
-        knife,
-        Uri.parse("android.resource://com.github.HumanLearning2021.HumanLearningApp/" + R.drawable.knife)
-    )
-    private val spoonPic = DummyCategorizedPicture(
-        "spoonpicid",
-        spoon,
-        Uri.parse("android.resource://com.github.HumanLearning2021.HumanLearningApp/" + R.drawable.spoon)
-    )
-
-    private val forkRepPic = DummyCategorizedPicture(
-        "forkPic1Id",
-        fork,
-        Uri.parse("android.resource://com.github.HumanLearning2021.HumanLearningApp/" + R.drawable.fork_rep)
-    )
-    private val knifeRepPic = DummyCategorizedPicture(
-        "knifePic1Id",
-        knife,
-        Uri.parse("android.resource://com.github.HumanLearning2021.HumanLearningApp/" + R.drawable.knife_rep)
-    )
-    private val spoonRepPic = DummyCategorizedPicture(
-        "spoonPic1Id",
-        spoon,
-        Uri.parse("android.resource://com.github.HumanLearning2021.HumanLearningApp/" + R.drawable.spoon_rep)
-    )
-
-    private val pictures: MutableSet<DummyCategorizedPicture> =
-        mutableSetOf(forkPic, knifePic, spoonPic)
-    private val categories: MutableSet<DummyCategory> = mutableSetOf(fork, fork2, knife, spoon)
-    private val datasets: MutableSet<DummyDataset> =
-        mutableSetOf(
-            DummyDataset("kitchen utensils", "kitchen utensils", setOf(fork, knife, spoon)),
-            DummyDataset("one category", "one category", setOf(fork)),
-            DummyDataset("two categories", "two categories", setOf(fork, knife)),
-            DummyDataset(
-                "four categories", "four categories",
-                setOf(fork, knife, spoon, fork2)
-            ),
-        )
+    private val pictures = InMemoryRepository<CategorizedPicture>()
+    private val categories = InMemoryRepository<Category>()
+    private val datasets = InMemoryRepository<Dataset>()
     private val representativePictures: MutableMap<String, CategorizedPicture> = mutableMapOf()
-    private val users = mutableMapOf<User.Id, User>()
-    private val statistics = mutableMapOf<Statistic.Id, Statistic>()
+    private val users = InMemoryRepository<User>()
+    private val statistics = InMemoryRepository<Statistic>()
 
-    init {
-        representativePictures["Fork"] = forkRepPic
-        representativePictures["Fork2"] = forkRepPic
-        representativePictures["Knife"] = knifeRepPic
-        representativePictures["Spoon"] = spoonRepPic
+    private suspend fun requireCategoryPresent(category: Category) {
+        categories.getById(category.id) ?: throw DatabaseService.NotFoundException(category.id)
     }
 
+    private suspend fun requireDatasetPresent(dataset: Dataset) {
+        datasets.getById(dataset.id) ?: throw DatabaseService.NotFoundException(dataset.id)
+    }
+
+    private suspend fun requirePicturePresent(picture: CategorizedPicture) {
+        pictures.getById(picture.id) ?: throw DatabaseService.NotFoundException(picture.id)
+    }
 
     override suspend fun getPicture(category: Category): CategorizedPicture? {
-        require(category is DummyCategory)
         requireCategoryPresent(category)
 
-        for (p in pictures)
-            if (p.category == category) return p
-        return null
+        return pictures.getIds().map { pictures.getById(it) }
+            .find { it?.category?.id == category.id }
     }
 
-    override suspend fun getPicture(pictureId: Id): CategorizedPicture? {
-        for (p in pictures)
-            if (p.id == pictureId) return p
-        return null
-    }
+    override suspend fun getPicture(pictureId: Id): CategorizedPicture? =
+        pictures.getById(pictureId)
 
     override suspend fun getPictureIds(category: Category): List<Id> {
-        require(category is DummyCategory)
         requireCategoryPresent(category)
-
-        val res = mutableListOf<String>()
-        for (p in pictures)
-            if (p.category == category) res.add(p.id)
-        return res
+        return pictures.getIds().filter { pictures.getById(it)?.category?.id == category.id }
     }
 
     override suspend fun getRepresentativePicture(categoryId: Id): CategorizedPicture? {
@@ -105,187 +48,111 @@ class DummyDatabaseService internal constructor() : DatabaseService {
     }
 
     override suspend fun putPicture(picture: Uri, category: Category): CategorizedPicture {
-        require(category is DummyCategory)
         requireCategoryPresent(category)
 
-        val addedPicture = DummyCategorizedPicture("${UUID.randomUUID()}", category, picture)
-        pictures.add(addedPicture)
+        val addedPicture = DummyCategorizedPicture("", category, picture)
+        val id = pictures.createWith { addedPicture.copy(id = it) }
 
-        return addedPicture
+        return addedPicture.copy(id = id)
     }
 
-    private fun requireCategoryPresent(category: Category) {
-        if (!categories.contains(category)) throw DatabaseService.NotFoundException(category.id)
+    override suspend fun getCategory(id: Id): Category? {
+        return categories.getById(id)
     }
-
-    override suspend fun getCategory(id: Id): Category? = categories.find { it.id == id }
 
     override suspend fun putCategory(categoryName: String): Category {
-        val category = DummyCategory(categoryName, categoryName)
-        categories.add(category)
+        val category = Category(categoryName, categoryName)
+        categories.update(categoryName, category)
         return category
     }
 
     override suspend fun getCategories(): Set<Category> {
-        return Collections.unmodifiableSet(categories)
+        return categories.getIds().mapNotNull { categories.getById(it) }.toSet()
     }
 
     override suspend fun getAllPictures(category: Category): Set<CategorizedPicture> {
-        require(category is DummyCategory)
         requireCategoryPresent(category)
-        val res: MutableSet<CategorizedPicture> = mutableSetOf()
-        for (p in pictures) {
-            if (p.category == category) {
-                res.add(p)
-            }
-        }
-        return res
+
+        return getPictureIds(category).mapNotNull { pictures.getById(it) }.toSet()
     }
 
     override suspend fun removeCategory(category: Category) {
-        require(category is DummyCategory)
         requireCategoryPresent(category)
-
-        categories.remove(category)
-        val datasetsToUpdate = datasets.filter { it.categories.contains(category) }
-        val updatedDatasets =
-            datasetsToUpdate.map { removeCategoryFromDataset(it, category) }
-        datasets.removeAll(datasetsToUpdate)
-        datasets.addAll(updatedDatasets)
+        datasets.updateAll {
+            it.copy(categories = it.categories - category)
+        }
+        categories.delete(category.id)
     }
 
     override suspend fun removePicture(picture: CategorizedPicture) {
-        require(picture is DummyCategorizedPicture)
-        for (p in pictures) {
-            if (p.id == picture.id) {
-                pictures.remove(p)
-                return
-            }
-        }
-        throw DatabaseService.NotFoundException(picture.id)
+        if (!pictures.delete(picture.id)) throw DatabaseService.NotFoundException(picture.id)
     }
 
     override suspend fun putDataset(name: String, categories: Set<Category>): Dataset {
-        val dataset = DummyDataset(name, name, categories)
-        datasets.add(dataset)
+        val dataset = Dataset(name, name, categories)
+        datasets.update(name, dataset)
         return dataset
     }
 
-    override suspend fun getDataset(id: Id): Dataset? = datasets.find { it.id == id }
-
+    override suspend fun getDataset(id: Id): Dataset? =
+        datasets.getById(id)
 
     override suspend fun deleteDataset(id: Id) {
-        for (d in datasets) {
-            if (d.name == id) {
-                datasets.remove(d)
-                return
-            }
-        }
-        throw DatabaseService.NotFoundException(id)
+        if (!datasets.delete(id)) throw DatabaseService.NotFoundException(id)
     }
 
     override suspend fun putRepresentativePicture(picture: Uri, category: Category) {
         requireCategoryPresent(category)
-
         representativePictures[category.id] =
             DummyCategorizedPicture("${UUID.randomUUID()}", category, picture)
     }
 
     override suspend fun putRepresentativePicture(picture: CategorizedPicture) {
         require(picture is DummyCategorizedPicture)
+        requirePicturePresent(picture)
         putRepresentativePicture(picture.picture, picture.category)
-        pictures.remove(picture)
+        pictures.delete(picture.id)
     }
 
     override suspend fun getDatasets(): Set<Dataset> {
-        return datasets
+        return datasets.getIds().mapNotNull { datasets.getById(it) }.toSet()
     }
 
     override suspend fun removeCategoryFromDataset(
         dataset: Dataset,
         category: Category
-    ): DummyDataset {
-        require(dataset is DummyDataset)
-        require(category is DummyCategory)
+    ): Dataset {
         requireDatasetPresent(dataset)
-
-        for (c in dataset.categories) {
-            if (c == category) {
-                val newCategories: MutableSet<Category> = mutableSetOf()
-                newCategories.apply {
-                    addAll(dataset.categories)
-                    remove(c)
-                }
-                val newDs =
-                    DummyDataset(dataset.id, dataset.name, newCategories as Set<Category>)
-                datasets.apply {
-                    add(newDs)
-                    remove(dataset)
-                }
-                return newDs
-            }
+        return dataset.copy(categories = dataset.categories - category).also {
+            datasets.update(it.id, it)
         }
-        throw DatabaseService.NotFoundException(category.id)
     }
 
     override suspend fun editDatasetName(dataset: Dataset, newName: String): Dataset {
-        require(dataset is DummyDataset)
         requireDatasetPresent(dataset)
-        val newDs = DummyDataset(dataset.id, newName, dataset.categories)
-        datasets.apply {
-            add(newDs)
-            remove(dataset)
-        }
-        return newDs
-    }
-
-    private fun requireDatasetPresent(dataset: Dataset) {
-
-        // calling datasets.contains(dataset) returned false for obviously equal datasets
-        if (!datasets.contains(dataset)) {
-            Log.e(
-                this::class.java.simpleName,
-                "The underlying database:\n $datasets\n\n does not " +
-                        "contain the dataset \n $dataset"
-            )
-            throw DatabaseService.NotFoundException(dataset.id)
-        }
+        return dataset.copy(name = newName).also { datasets.update(dataset.id, it) }
     }
 
     override suspend fun addCategoryToDataset(dataset: Dataset, category: Category): Dataset {
-        require(dataset is DummyDataset)
-        require(category is DummyCategory)
         requireCategoryPresent(category)
         requireDatasetPresent(dataset)
-
         return if (dataset.categories.contains(category)) {
             dataset
         } else {
-            val newCats = mutableSetOf<Category>()
-            newCats.apply {
-                addAll(dataset.categories)
-                add(category)
+            dataset.copy(categories = dataset.categories + category).also {
+                datasets.update(it.id, it)
             }
-            val newDs = DummyDataset(dataset.id, dataset.name, newCats)
-            datasets.apply {
-                remove(dataset)
-                add(newDs)
-            }
-            newDs
         }
     }
 
-    override suspend fun updateUser(firebaseUser: FirebaseUser): User {
-        val type = User.Type.FIREBASE
-        val uid = firebaseUser.uid
-        return DummyUser(
-            type = type,
-            uid = uid,
+    override suspend fun updateUser(firebaseUser: FirebaseUser) =
+        User(
+            type = User.Type.FIREBASE,
+            uid = firebaseUser.uid,
             email = firebaseUser.email,
             displayName = firebaseUser.displayName,
             isAdmin = false
-        ).also { users[it.id] = it }
-    }
+        ).also { users.update(it.id.toString(), it) }
 
     override suspend fun setAdminAccess(firebaseUser: FirebaseUser, adminAccess: Boolean): User {
         val type = User.Type.FIREBASE
@@ -296,19 +163,20 @@ class DummyDatabaseService internal constructor() : DatabaseService {
             email = firebaseUser.email,
             displayName = firebaseUser.displayName,
             isAdmin = adminAccess
-        ).also { users[it.id] = it }
+        ).also { users.update(it.id.toString(), it) }
     }
 
     override suspend fun checkIsAdmin(user: User): Boolean {
         return user.isAdmin
     }
 
-    override suspend fun getUser(type: User.Type, uid: String) = users[User.Id(uid, type)]
+    override suspend fun getUser(type: User.Type, uid: String) =
+        users.getById(User.Id(uid, type).toString())
 
     override suspend fun getStatistic(userId: User.Id, datasetId: Id): Statistic? =
-        statistics[Statistic.Id(userId, datasetId)]
+        statistics.getById(Statistic.Id(userId, datasetId).toString())
 
     override suspend fun putStatistic(statistic: Statistic) {
-        statistics[statistic.id] = statistic
+        statistics.update(statistic.id.toString(), statistic)
     }
 }

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/InMemoryRepository.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/InMemoryRepository.kt
@@ -1,0 +1,58 @@
+package com.github.HumanLearning2021.HumanLearningApp.model
+
+import android.util.Base64
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.random.Random
+
+/**
+ * In-memory, impermanent key-value storage.
+ */
+class InMemoryRepository<V>(
+    private val random: Random = Random,
+) : Repository<String, V> {
+
+    private inner class Context {
+        var data = mutableMapOf<String, V>()
+    }
+
+    private val mutex = Mutex()
+    private val ctx = Context()
+    private suspend fun <R> withContext(action: Context.() -> R): R = mutex.withLock {
+        ctx.action()
+    }
+
+    suspend fun createWith(fkv: (String) -> V) = withContext {
+        var k: String
+        do {
+            k = Base64.encodeToString(random.nextBytes(15), Base64.URL_SAFE)
+        } while (k in data)
+        data[k] = fkv(k)
+        k
+    }
+
+    override suspend fun updateWith(k: String, f: (V?) -> V?) = withContext {
+        f(data[k])?.let { data[k] = it }
+        Unit
+    }
+
+    override suspend fun getById(k: String) = withContext {
+        data[k]
+    }
+
+    override suspend fun delete(k: String): Boolean = withContext { data.remove(k) != null }
+
+    override suspend fun getIds() = withContext { data.keys }
+
+    override suspend fun updateAll(f: (V) -> V) = withContext {
+        for ((k, v) in data) {
+            data[k] = f(v)
+        }
+    }
+
+    override suspend fun update(k: String, v: V) = withContext {
+        data[k] = v
+    }
+
+    override suspend fun create(v: V): String = createWith { v }
+}

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/Repository.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/model/Repository.kt
@@ -1,0 +1,57 @@
+package com.github.HumanLearning2021.HumanLearningApp.model
+
+/**
+ * Generic definition of homogenous key-value storage.
+ *
+ * [Reference](https://medium.com/@pererikbergman/repository-design-pattern-e28c0f3e4a30)
+ *
+ */
+interface Repository<K, V> {
+    /**
+     * Add an entry to the data, assigning it a new key.
+     * @param v the data to store.
+     * @return the new key
+     */
+    suspend fun create(v: V): K
+
+    /**
+     * Change the data at a specific key.
+     * @param k the key
+     * @param v the new value
+     */
+    suspend fun update(k: K, v: V)
+
+    /**
+     * Transform the data stored at a given key
+     * @param k the key
+     * @param v a pure function to change the stored value
+     */
+    suspend fun updateWith(k: K, f: (V?) -> V?)
+
+    /**
+     * Retrieve the data stored at a given key
+     * @param k the key
+     * @return the data retrieved, or null if nothing is stored
+     */
+    suspend fun getById(k: K): V?
+
+    /**
+     * Discard the data stored at a given key.
+     * @param k the key
+     * @return `false` if the nothing was stored, `true` otherwise
+     */
+    suspend fun delete(k: K): Boolean
+
+    /**
+     * Collect all keys where something is stored.
+     * @return the set of the keys of all non-empty entries
+     */
+    suspend fun getIds(): Set<K>
+
+    /**
+     * Transform the data stored key-by-key.
+     * @param f a pure function to alter the data of one entry.
+     */
+    suspend fun updateAll(f: (V) -> V)
+}
+


### PR DESCRIPTION
Depends on #180 

Close #177 

It should be possible to write a Repository for a Firestore collection, a couple Repository adapters, and ultimately dismantle DatabaseService.