### PR TITLE
add image compression

### DIFF
--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayDatasetActivityTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayDatasetActivityTest.kt
@@ -1,7 +1,6 @@
 package com.github.HumanLearning2021.HumanLearningApp.view.dataset_editing
 
 import android.Manifest
-import android.content.Context
 import android.content.Intent
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
@@ -34,7 +33,6 @@ import com.github.HumanLearning2021.HumanLearningApp.view.dataset_list_fragment.
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.schibsted.spain.barista.interaction.PermissionGranter
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -77,10 +75,6 @@ class DisplayDatasetActivityTest {
     @ProductionDatabaseName
     var dbName = "dummy"
 
-    @Inject
-    @ApplicationContext
-    lateinit var context: Context
-
     lateinit var dbMgt: DatabaseManagement
 
     @BindValue
@@ -109,7 +103,6 @@ class DisplayDatasetActivityTest {
         }
 
         Intents.init()
-        context.cacheDir.deleteRecursively()
     }
 
     @After

--- a/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/TakePictureActivityTest.kt
+++ b/app/src/androidTest/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/TakePictureActivityTest.kt
@@ -1,7 +1,6 @@
 package com.github.HumanLearning2021.HumanLearningApp.view.dataset_editing
 
 import android.Manifest
-import android.content.Context
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
@@ -25,7 +24,6 @@ import com.github.HumanLearning2021.HumanLearningApp.model.DatabaseManagement
 import com.github.HumanLearning2021.HumanLearningApp.model.UniqueDatabaseManagement
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.schibsted.spain.barista.interaction.PermissionGranter
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -58,10 +56,6 @@ class TakePictureActivityTest {
     @ProductionDatabaseName
     var dbName = "dummy"
 
-    @Inject
-    @ApplicationContext
-    lateinit var context: Context
-
     lateinit var dbMgt: DatabaseManagement
 
     lateinit var datasetId: String
@@ -83,7 +77,6 @@ class TakePictureActivityTest {
     @Before
     fun setUp() {
         hiltRule.inject()
-        context.cacheDir.deleteRecursively()
         dbMgt = globalDatabaseManagement.accessDatabase(dbName)
         TestUtils.getFirstDataset(dbMgt).id
         datasetId = TestUtils.getFirstDataset(dbMgt).id

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureFragment.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureFragment.kt
@@ -1,5 +1,8 @@
 package com.github.HumanLearning2021.HumanLearningApp.view.dataset_editing
 
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -14,6 +17,9 @@ import androidx.navigation.fragment.navArgs
 import com.github.HumanLearning2021.HumanLearningApp.databinding.FragmentAddPictureBinding
 import com.github.HumanLearning2021.HumanLearningApp.model.Category
 import com.github.HumanLearning2021.HumanLearningApp.model.Id
+import java.io.File
+import java.io.FileOutputStream
+import java.util.*
 
 class AddPictureFragment : Fragment() {
 
@@ -35,7 +41,21 @@ class AddPictureFragment : Fragment() {
     }
 
     companion object {
+        private const val imageCompressionQuality = 25
         const val REQUEST_KEY = "AddPictureFragmentRequestKey"
+
+        fun applyImageSizeReduction(bitmap: Bitmap, context: Context): Uri {
+            // random string as name as a fallback in case the app crashes and the image file does
+            // not get deleted, avoids crashes during image taking process.
+            val file = File(
+                context.cacheDir,
+                UUID.randomUUID().toString()
+            )
+            val fileOutputStream = FileOutputStream(file)
+            bitmap.compress(Bitmap.CompressFormat.JPEG, imageCompressionQuality, fileOutputStream)
+            fileOutputStream.close()
+            return Uri.fromFile(file)
+        }
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureFragment.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/AddPictureFragment.kt
@@ -38,7 +38,6 @@ class AddPictureFragment : Fragment() {
         const val REQUEST_KEY = "AddPictureFragmentRequestKey"
     }
 
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayDatasetFragment.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/DisplayDatasetFragment.kt
@@ -23,6 +23,7 @@ import com.github.HumanLearning2021.HumanLearningApp.model.*
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.io.File
 import javax.inject.Inject
 
 
@@ -65,6 +66,7 @@ class DisplayDatasetFragment : Fragment() {
             val chosenCategory = bundle.getParcelable<Category>("chosenCategory")
             lifecycleScope.launch {
                 dbManagement.putPicture(pictureUri!!, chosenCategory!!)
+                File(pictureUri.path!!).delete()
             }
         }
     }

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/SelectPictureFragment.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/SelectPictureFragment.kt
@@ -1,12 +1,16 @@
 package com.github.HumanLearning2021.HumanLearningApp.view.dataset_editing
 
 import android.content.Intent
+import android.graphics.ImageDecoder.createSource
+import android.graphics.ImageDecoder.decodeBitmap
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat.getColor
 import androidx.core.os.bundleOf
@@ -85,13 +89,21 @@ class SelectPictureFragment : Fragment() {
         startActivityForResult(intent, RC_OPEN_PICTURE)
     }
 
+    @RequiresApi(Build.VERSION_CODES.P)
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         @Suppress("DEPRECATION")
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {
             RC_OPEN_PICTURE -> {
                 data?.data?.also {
-                    selectedPicture = it
+                    val bitmap =
+                        decodeBitmap(
+                            createSource(
+                                requireContext().contentResolver, it
+                            )
+                        )
+                    selectedPicture =
+                        AddPictureFragment.applyImageSizeReduction(bitmap, requireContext())
                     displayPicture(it)
                     notifySaveButton()
                 }

--- a/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/TakePictureFragment.kt
+++ b/app/src/main/java/com/github/HumanLearning2021/HumanLearningApp/view/dataset_editing/TakePictureFragment.kt
@@ -2,7 +2,6 @@ package com.github.HumanLearning2021.HumanLearningApp.view.dataset_editing
 
 import android.Manifest
 import android.content.pm.PackageManager
-import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.drawable.Drawable
 import android.net.Uri
@@ -36,8 +35,6 @@ import com.github.HumanLearning2021.HumanLearningApp.databinding.FragmentTakePic
 import com.github.HumanLearning2021.HumanLearningApp.model.Category
 import com.github.HumanLearning2021.HumanLearningApp.model.Id
 import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.FileOutputStream
 import java.util.concurrent.Executors
 
 class TakePictureFragment : Fragment() {
@@ -140,22 +137,16 @@ class TakePictureFragment : Fragment() {
 
                 override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
                     parentActivity.runOnUiThread {
-                        pictureUri = applyImageSizeReduction(outputStream.toByteArray())
+                        val bytes = outputStream.toByteArray()
+                        val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                        pictureUri =
+                            AddPictureFragment.applyImageSizeReduction(bitmap, requireContext())
                         imageTaken = true
                         setCaptureButton()
                         notifySaveButton()
                     }
                 }
             })
-    }
-
-    private fun applyImageSizeReduction(bytes: ByteArray): Uri {
-        val file = File(parentActivity.filesDir, "temp")
-        val fileOutputStream = FileOutputStream(file)
-        val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-        bitmap.compress(Bitmap.CompressFormat.JPEG, 25, fileOutputStream)
-        fileOutputStream.close()
-        return Uri.fromFile(file)
     }
 
     @Suppress("UNUSED_PARAMETER")


### PR DESCRIPTION
Compress images before uploading. This way they take up less space in storage and load faster.
Also took the opportunity to improve the camery reliability by fixing the bug where it would no longer take pictures successfully if the app crashed before uploading the last picture taken.